### PR TITLE
Implemented XScreenSaverQueryInfo to retrieve screen saver information

### DIFF
--- a/X11/Screensaver.cs
+++ b/X11/Screensaver.cs
@@ -22,6 +22,17 @@ namespace X11
         PreferBlanking = 1,
         DefaultBlanking = 2,
     }
+    
+    [StructLayout(LayoutKind.Sequential)]
+    public struct XScreenSaverInfo
+    {
+        public Window window;
+        public int state;
+        public int kind;
+        public ulong til_or_since;
+        public ulong idle;
+        public ulong eventMask;
+    }
 
     public partial class Xlib
     {
@@ -41,5 +52,8 @@ namespace X11
         [DllImport("libX11.so.6")]
         public static extern Status XGetScreenSaver(IntPtr display, ref int timeout_return, ref int interval_return, 
             ref ScreenSaverBlanking prefer_blanking_return, ref ScreenSaverExposures allow_exposures_return);
+
+        [DllImport("libXss.so.1")]
+        public static extern Status XScreenSaverQueryInfo(IntPtr display, Window drawable, ref XScreenSaverInfo saver_info);
     }
 }


### PR DESCRIPTION
I've added `XScreenSaverQueryInfo()` and `struct XScreenSaverInfo`.

Here is an example code that uses this method to detect mouse movements:
```C#
public static class Program
{
    public static async Task Main(string[] args)
    {
        IntPtr displayPtr = Xlib.XOpenDisplay(":0");
        if (displayPtr == IntPtr.Zero)
        {
            Console.WriteLine("Could not open display");
            return;
        }

        Window rootWindow = Xlib.XDefaultRootWindow(displayPtr);

        using var cancelSource = new CancellationTokenSource();
        Console.CancelKeyPress += (sender, eventArgs) => cancelSource.Cancel();

        while (!cancelSource.IsCancellationRequested)
        {
            XScreenSaverInfo info = default;
            Xlib.XScreenSaverQueryInfo(displayPtr, rootWindow, ref info);
            Console.WriteLine(TimeSpan.FromMilliseconds(info.idle));

            await Task.Delay(TimeSpan.FromSeconds(0.1)).ConfigureAwait(false);
        }

        Xlib.XCloseDisplay(displayPtr);
    }
}
```